### PR TITLE
Testing get_prescription_gaps

### DIFF
--- a/analysis/dataset_definition/add_variables.py
+++ b/analysis/dataset_definition/add_variables.py
@@ -261,7 +261,7 @@ def add_out_variables(dataset, index_date, start_date, end_date, medication_code
 
 
     ## Number of days between prescription dates of antihypertensives
-    get_prescription_gaps(dataset, start_date, end_date, medication_codelist, column_suffix, 10)
+    get_prescription_gaps(dataset, start_date, end_date, medication_codelist, column_suffix, 100)
 
     # ---- Add variables to dataset ----
     dataset.add_column(f"out_dat_next_{column_suffix}", out_dat_next_med)

--- a/analysis/dataset_definition/dataset_definition_hist.py
+++ b/analysis/dataset_definition/dataset_definition_hist.py
@@ -50,10 +50,10 @@ add_covariates(dataset, index_date, end_date)
 
 ## Outcome Variables
 add_out_variables(dataset, index_date, start_date, end_date, ace_inhibitor_codelist, "acei")
-add_out_variables(dataset, index_date, start_date, end_date, alpha_adrenoceptor_blocking_drugs_codelist, "aab")
-add_out_variables(dataset, index_date, start_date, end_date, angiotensin_ii_receptor_blockers_codelist, "arb")
-add_out_variables(dataset, index_date, start_date, end_date, beta_blockers_codelist, "bb")
-add_out_variables(dataset, index_date, start_date, end_date, calcium_channel_blockers_codelist, "ccb")
+#add_out_variables(dataset, index_date, start_date, end_date, alpha_adrenoceptor_blocking_drugs_codelist, "aab")
+#add_out_variables(dataset, index_date, start_date, end_date, angiotensin_ii_receptor_blockers_codelist, "arb")
+#add_out_variables(dataset, index_date, start_date, end_date, beta_blockers_codelist, "bb")
+#add_out_variables(dataset, index_date, start_date, end_date, calcium_channel_blockers_codelist, "ccb")
 #add_out_variables(dataset, index_date, start_date, end_date, centrally_acting_antihypertensives_codelist, "caa")
 
 ##Define population


### PR DESCRIPTION
In this commit we adjust `dataset_definition_hist` so that we are only looking at one of the codelists of interest. We also up `limit` to 100 for running on the real dataset. This is a test to see what the run time will look like for get_prescription_gaps.